### PR TITLE
verify fare amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,17 +100,4 @@ Testing http://localhost:51544/v1
 
   16 passing (603ms)
   1 pending
-
-
-The calculated fare amount is not as expected at some hours. For instance, the higher fare should be in effect at 23pm local time but the lower fare is recorded in the order. The reverse is true at 10am. See debug output below:
-
-Order time: 2019-08-10T15:55:11Z (23:55pm HK time)
-Fare expected: 197.76
-Fare recorded: 124.85
-
-Order time: 2019-08-10T02:24:34Z (10:24am HK time)
-Fare expected: 2631.45
-Fare recorded: 4208.32
-
-Until this potential issue is resolved, this PR should not be merged.
 ```

--- a/README.md
+++ b/README.md
@@ -30,19 +30,56 @@ Testing http://localhost:51544/v1
 
   Order Processing API
     Place Order
-      delivery in Hong Kong
-        ✓ creates a new order (1006ms)
-      delivery in Ho Chi Minh City
-        ✓ creates a new order (112ms)
+      immediate delivery in Hong Kong
+        ✓ creates a new order (1356ms)
+      scheduled delivery in Ho Chi Minh City
+        ✓ creates a new order (1213ms)
       delivery in a non-serviced country
-        ✓ does not create an order (110ms)
+        ✓ does not create an order (171ms)
       for each order created
         ✓ assigns a numeric order id - 2/2
         ✓ calculates distances - 2/2
-        ✓ calculates fare - 2/2
     Fetch Order Details
       for each order fetched
-        ✓ provides distances, fare, and status - 2/2
+        ✓ provides status - 2/2
+        ✓ provides distances - 2/2
+        1) calculates fare - 1/2
+
+
+  7 passing (3s)
+  1 failing
+
+  1) Order Processing API
+       Fetch Order Details
+         for each order fetched
+           calculates fare - 1/2:
+     Uncaught AssertionError: expected 1055.85 to be within 1686.86..1687.86
+      at chai.request.get.end (test/process_order.js:99:30)
+      at Test.Request.callback (node_modules/superagent/lib/node/index.js:716:12)
+      at parser (node_modules/superagent/lib/node/index.js:916:18)
+      at IncomingMessage.res.on (node_modules/superagent/lib/node/parsers/json.js:19:7)
+      at endReadableNT (_stream_readable.js:1129:12)
+      at process._tickCallback (internal/process/next_tick.js:63:19)
+
+
+Testing http://localhost:51544/v1
+
+  Order Processing API
+    Place Order
+      immediate delivery in Hong Kong
+        ✓ creates a new order (256ms)
+      scheduled delivery in Ho Chi Minh City
+        ✓ creates a new order (154ms)
+      delivery in a non-serviced country
+        ✓ does not create an order (73ms)
+      for each order created
+        ✓ assigns a numeric order id - 2/2
+        ✓ calculates distances - 2/2
+    Fetch Order Details
+      for each order fetched
+        ✓ provides status - 2/2
+        ✓ provides distances - 2/2
+        - calculates fare
       if order not found
         ✓ returns a client error
     Driver to Take the Order
@@ -61,5 +98,19 @@ Testing http://localhost:51544/v1
         ✓ the order cannot be taken
 
 
-  16 passing (1s)
+  16 passing (603ms)
+  1 pending
+
+
+The calculated fare amount is not as expected at some hours. For instance, the higher fare should be in effect at 23pm local time but the lower fare is recorded in the order. The reverse is true at 10am. See debug output below:
+
+Order time: 2019-08-10T15:55:11Z (23:55pm HK time)
+Fare expected: 197.76
+Fare recorded: 124.85
+
+Order time: 2019-08-10T02:24:34Z (10:24am HK time)
+Fare expected: 2631.45
+Fare recorded: 4208.32
+
+Until this potential issue is resolved, this PR should not be merged.
 ```

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Testing http://localhost:51544/v1
   Order Processing API
     Place Order
       immediate delivery in Hong Kong
-        ✓ creates a new order (1356ms)
+        ✓ creates a new order (216ms)
       scheduled delivery in Ho Chi Minh City
-        ✓ creates a new order (1213ms)
+        ✓ creates a new order (164ms)
       delivery in a non-serviced country
-        ✓ does not create an order (171ms)
+        ✓ does not create an order (117ms)
       for each order created
         ✓ assigns a numeric order id - 2/2
         ✓ calculates distances - 2/2
@@ -43,61 +43,24 @@ Testing http://localhost:51544/v1
       for each order fetched
         ✓ provides status - 2/2
         ✓ provides distances - 2/2
-        1) calculates fare - 1/2
-
-
-  7 passing (3s)
-  1 failing
-
-  1) Order Processing API
-       Fetch Order Details
-         for each order fetched
-           calculates fare - 1/2:
-     Uncaught AssertionError: expected 1055.85 to be within 1686.86..1687.86
-      at chai.request.get.end (test/process_order.js:99:30)
-      at Test.Request.callback (node_modules/superagent/lib/node/index.js:716:12)
-      at parser (node_modules/superagent/lib/node/index.js:916:18)
-      at IncomingMessage.res.on (node_modules/superagent/lib/node/parsers/json.js:19:7)
-      at endReadableNT (_stream_readable.js:1129:12)
-      at process._tickCallback (internal/process/next_tick.js:63:19)
-
-
-Testing http://localhost:51544/v1
-
-  Order Processing API
-    Place Order
-      immediate delivery in Hong Kong
-        ✓ creates a new order (256ms)
-      scheduled delivery in Ho Chi Minh City
-        ✓ creates a new order (154ms)
-      delivery in a non-serviced country
-        ✓ does not create an order (73ms)
-      for each order created
-        ✓ assigns a numeric order id - 2/2
-        ✓ calculates distances - 2/2
-    Fetch Order Details
-      for each order fetched
-        ✓ provides status - 2/2
-        ✓ provides distances - 2/2
-        - calculates fare
+        ✓ calculates fare - 2/2 (246ms)
       if order not found
         ✓ returns a client error
     Driver to Take the Order
       ✓ advances the order to Ongoing status
       if order not found
-        ✓ returns a client error
+        ✓ returns a client error (67ms)
     Driver to Complete the Order
       ✓ advances the order to Completed status
       once completed
         ✓ the order cannot be cancelled
         ✓ the order cannot be taken again
     Cancel Order
-      ✓ advances the order to Cancelled status
+      ✓ advances the order to Cancelled status (83ms)
       once cancelled
         ✓ the order cannot be completed
-        ✓ the order cannot be taken
+        ✓ the order cannot be taken (78ms)
 
 
-  16 passing (603ms)
-  1 pending
+  17 passing (1s)
 ```

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
     "it-each": "^0.4.0",
+    "lodash": "^4.17.15",
     "mocha": "^6.2.0"
   },
   "dependencies": {}

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,4 +1,5 @@
 const chai = require('chai');
+const _ = require('lodash');
 const chaiHttp = require('chai-http');
 chai.should();
 chai.use(chaiHttp);
@@ -16,16 +17,27 @@ module.exports = {
 		var num_places = 2 + Math.round(Math.random() * (PLACES[city].length - 2))
 		return PLACES[city].slice(0, num_places) 
 	},
-	calculateFareRange: (distanceMeters) => {
-		var distanceOver2km = distanceMeters - 2000.0;
-		var baseFare = { low: 20, high: 30 };
-		var incrementFare = { low: 5, high: 8 };
-		if (distanceOver2km <= 0) {
-			return [ basePrice.low, basePrice.high ]
+	localTime: (time, timezone) => {
+		return new Date(new Date(time).toLocaleString('en-US', {timeZone: timezone})).toLocaleString();
+	},
+	sometimeTomorrow: () => {
+		var d = new Date();
+		start = d.setHours(0,0,0);
+		end = d.setHours(23,59,59);
+		return new Date(start + Math.random() * (end - start)).toISOString();
+	},
+	calculateFare: (distanceMeters, localTime) => {
+		var baseFare, incrementalFare;
+		if (_.inRange(new Date(localTime).getHours(), 5, 22)) {
+			baseFare = 20;
+			incrementalFare = 5;
 		}
 		else {
-			return [ baseFare.low + distanceOver2km / 200 * incrementFare.low, baseFare.high + distanceOver2km / 200 * incrementFare.high ]
+			baseFare = 30;
+			incrementalFare = 8;
 		}
+		return baseFare + incrementalFare * Math.max(distanceMeters - 2000, 0) / 200.0;
 	},
-	chai
+	chai,
+	_
 }


### PR DESCRIPTION
**this branch has pending issues and should be not be merged.**
This PR updates the calculate fares scenario to test for specific amount. 

The API does not return the expected fare amount at some hours. For instance, the higher fare should be in effect at 23pm local time but the lower fare is recorded in the order. The reverse is true at 10am. See debug output below:

Order time: 2019-08-10T15:55:11Z (23:55pm HK time)
Fare expected: 197.76
Fare recorded: 124.85

Order time: 2019-08-10T02:24:34Z (10:24am HK time)
Fare expected: 2631.45
Fare recorded: 4208.32

Until this potential issue is resolved, this PR should not be merged.

test output below:
```
Your branch is up to date with 'origin/verify-exact-fare'.
Lis-MacBook-Pro:api_tests lirachel$ npm test

> api_tests@1.0.0 test /Users/lirachel/kfung/api_tests
> mocha --bail test



Testing http://localhost:51544/v1

  Order Processing API
    Place Order
      immediate delivery in Hong Kong
        ✓ creates a new order (250ms)
      scheduled delivery in Ho Chi Minh City
        ✓ creates a new order (716ms)
      delivery in a non-serviced country
        ✓ does not create an order (88ms)
      for each order created
        ✓ assigns a numeric order id - 2/2
        ✓ calculates distances - 2/2
    Fetch Order Details
      for each order fetched
        ✓ provides status - 2/2
        ✓ provides distances - 2/2
        1) calculates fare - 1/2


  7 passing (1s)
  1 failing

  1) Order Processing API
       Fetch Order Details
         for each order fetched
           calculates fare - 1/2:
     Uncaught AssertionError: expected 2846.72 to be within 1779.95..1780.95
      at chai.request.get.end (test/process_order.js:98:30)
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:716:12)
      at parser (node_modules/superagent/lib/node/index.js:916:18)
      at IncomingMessage.res.on (node_modules/superagent/lib/node/parsers/json.js:19:7)
      at endReadableNT (_stream_readable.js:1129:12)
      at process._tickCallback (internal/process/next_tick.js:63:19)

```