### PR TITLE
state transition and order-not-found scenarios

### DIFF
--- a/test/process_order.js
+++ b/test/process_order.js
@@ -126,14 +126,19 @@ describe("Order Processing API", () => {
 	})
 
 	describe("Driver to Complete the Order", () => {
-		it('advances the order to Completed status', (done) => {
-			chai.request(API_URL)
-				.put(`/orders/${orderToComplete.id}/complete`)
-				.end((err, res) => {
-					res.should.have.status(200);
-					res.body['status'].should.match(/completed/i)
-					done();
-				})
+		context('when the order is taken', () => {
+			it('advances the order to Completed status', (done) => {
+				chai.request(API_URL)
+					.put(`/orders/${orderToComplete.id}/complete`)
+					.end((err, res) => {
+						res.should.have.status(200);
+						res.body['status'].should.match(/completed/i)
+						done();
+					})
+			})
+		})
+		context('when the order is not taken', () => {
+			it('the order cannot be completed')
 		})
 		context('once completed', () => {
 			it('the order cannot be cancelled', (done) => {
@@ -153,18 +158,33 @@ describe("Order Processing API", () => {
 					})
 			})
 		})
+		context('if order not found', () => {
+			it('returns a client error', (done) => {
+				chai.request(API_URL)
+					.put('/orders/0/complete')
+					.end((err, res) => {
+						res.status.should.be.within(400, 499);
+						done();
+					})
+			})
+		})
 	})
 
 	describe("Cancel Order", () => {
-		it('advances the order to Cancelled status', (done) => {
-			orderToCancel = newOrders[1];
-			chai.request(API_URL)
-				.put(`/orders/${orderToCancel.id}/cancel`)
-				.end((err, res) => {
-					res.should.have.status(200);
-					res.body['status'].should.match(/cancelled/i)
-					done();
-				})
+		context('when order is taken', () => {
+			it('advances the order to Cancelled status', (done) => {
+				orderToCancel = newOrders[1];
+				chai.request(API_URL)
+					.put(`/orders/${orderToCancel.id}/cancel`)
+					.end((err, res) => {
+						res.should.have.status(200);
+						res.body['status'].should.match(/cancelled/i)
+						done();
+					})
+			})
+		})
+		context('when order is not taken', () => {
+			it('advances the order to Cancelled status')
 		})
 		context('once cancelled', () => {
 			it('the order cannot be completed', (done) => {
@@ -180,6 +200,16 @@ describe("Order Processing API", () => {
 					.put(`/orders/${orderToCancel.id}/take`)
 					.end((err, res) => {
 						res.should.have.status(422);
+						done();
+					})
+			})
+		})
+		context('if order not found', () => {
+			it('returns a client error', (done) => {
+				chai.request(API_URL)
+					.put('/orders/0/cancel')
+					.end((err, res) => {
+						res.status.should.be.within(400, 499);
 						done();
 					})
 			})


### PR DESCRIPTION
This PR adds state transition scenarios; some are pending implementation.

Sample test output:
```
Testing http://localhost:51544/v1

  Order Processing API
    Place Order
      delivery in Hong Kong
        ✓ creates a new order (828ms)
      delivery in Ho Chi Minh City
        ✓ creates a new order (144ms)
      delivery in a non-serviced country
        ✓ does not create an order (85ms)
      for each order created
        ✓ assigns a numeric order id - 2/2
        ✓ calculates distances - 2/2
        ✓ calculates fare - 2/2
    Fetch Order Details
      for each order fetched
        ✓ provides distances, fare, and status - 2/2 (85ms)
      if order not found
        ✓ returns a client error
    Driver to Take the Order
      ✓ advances the order to Ongoing status
      if order not found
        ✓ returns a client error
    Driver to Complete the Order
      when the order is taken
        ✓ advances the order to Completed status (77ms)
      when the order is not taken
        - the order cannot be completed
      once completed
        ✓ the order cannot be cancelled
        ✓ the order cannot be taken again
      if order not found
        ✓ returns a client error
    Cancel Order
      when order is taken
        ✓ advances the order to Cancelled status
      when order is not taken
        - advances the order to Cancelled status
      once cancelled
        ✓ the order cannot be completed
        ✓ the order cannot be taken
      if order not found
        ✓ returns a client error


  18 passing (1s)
  2 pending
``` 